### PR TITLE
add https validation

### DIFF
--- a/app/src/main/java/ru/yourok/torrserve/ui/fragments/main/servfinder/ServerFinderFragment.kt
+++ b/app/src/main/java/ru/yourok/torrserve/ui/fragments/main/servfinder/ServerFinderFragment.kt
@@ -114,7 +114,8 @@ class ServerFinderFragment : TSFragment() {
                     host = "http://$host"
 
                 uri = Uri.parse(host) // no port, set default
-                if (uri.port == -1)
+                val isHttps = uri.scheme?.equals("https", true) == true
+                if (uri.port == -1 && !isHttps)
                     host += ":8090"
 
                 val oldHost = Settings.getHost()


### PR DESCRIPTION
added a simple https validation that fixes a pretty dumb problem - if the provided domain is https (defaults to 443), the app will add the port anyways. needs testing, though.