### PR TITLE
Support for external audio tracks in Vimu.

### DIFF
--- a/app/src/main/java/ru/yourok/torrserve/ui/activities/play/players/Vimu.kt
+++ b/app/src/main/java/ru/yourok/torrserve/ui/activities/play/players/Vimu.kt
@@ -35,6 +35,13 @@ object Vimu {
             intent.putStringArrayListExtra("asusfilelist", files)
             intent.putStringArrayListExtra("asusnamelist", names)
             intent.putExtra("startindex", idx)
+        } else {
+            val extAudio = TorrentHelper.getAudioFiles(torrent).map { audio ->
+                TorrentHelper.getFileLink(torrent, audio)
+            }
+            if (extAudio.isNotEmpty()) {
+                intent.putStringArrayListExtra("extsound", ArrayList(extAudio))
+            }
         }
         return intent
     }

--- a/app/src/main/java/ru/yourok/torrserve/utils/Mime.kt
+++ b/app/src/main/java/ru/yourok/torrserve/utils/Mime.kt
@@ -58,6 +58,7 @@ object Mime {
 
     val extAudio = listOf(
         "aac",
+        "ac3",
         "aiff",
         "ape",
         "au",

--- a/app/src/main/java/ru/yourok/torrserve/utils/TorrentHelper.kt
+++ b/app/src/main/java/ru/yourok/torrserve/utils/TorrentHelper.kt
@@ -44,7 +44,7 @@ object TorrentHelper {
             return playable?.get("audio") ?: emptyList()
         }
 
-        return playable?.get("video")?.filter {
+        return playable["video"]?.filter {
             val ext = File(it.path).extension.lowercase()
             return@filter when (ext) {
                 "m2ts", "mts", "ts" -> it.length > 524288000L

--- a/app/src/main/java/ru/yourok/torrserve/utils/TorrentHelper.kt
+++ b/app/src/main/java/ru/yourok/torrserve/utils/TorrentHelper.kt
@@ -26,25 +26,37 @@ object TorrentHelper {
             return emptyList()
 
         val files = torr.file_stats
-        val retList = mutableListOf<FileStat>()
 
-        files?.forEach {
-            val path = it.path
-            if (Mime.getMimeType(path) != "*/*") {
-                val size = it.length
-                if (File(path).extension.lowercase() == "m2ts" ||
-                    File(path).extension.lowercase() == "mts" ||
-                    File(path).extension.lowercase() == "ts"
-                ) {
-                    if (size > 524288000L) // 500MB 1073741824 = 1GB
-                        retList.add(it)
-                } else
-                    retList.add(it)
-            } else if (path.lowercase(Locale.getDefault()).contains("bdmv/index.bdmv")) {
-                retList.add(it)
+        val playable = files?.mapNotNull { file ->
+            val mime = Mime.getMimeType(file.path)
+            val isBdmv by lazy {
+                file.path.lowercase(Locale.getDefault()).contains("bdmv/index.bdmv")
             }
+            when {
+                mime.startsWith("audio") -> "audio" to file
+                mime.startsWith("video") -> "video" to file
+                isBdmv -> "video" to file
+                else -> null
+            }
+        }?.groupBy({ it.first }, { it.second })
+
+        if(playable?.get("video").isNullOrEmpty()) {
+            return playable?.get("audio") ?: emptyList()
         }
-        return retList
+
+        return playable?.get("video")?.filter {
+            val ext = File(it.path).extension.lowercase()
+            return@filter when (ext) {
+                "m2ts", "mts", "ts" -> it.length > 524288000L
+                else -> true
+            }
+        } ?: emptyList()
+    }
+
+    fun getAudioFiles(torr: Torrent): List<FileStat> {
+        return torr.file_stats?.filter { f ->
+            Mime.getMimeType(f.path).startsWith("audio")
+        } ?: emptyList()
     }
 
     fun waitFiles(hash: String): Torrent? {


### PR DESCRIPTION
пришлось чуть поменять логику. 
Если в раздаче вперемешку аудио и видео файлы, то считаем что аудио файлы - это внешние дорожки для видео. 
Иначе, на экране в плей-листе каша из файлов с различными Mime type. 
